### PR TITLE
remove color panel border, and remove extra spacing

### DIFF
--- a/library/src/main/java/com/jaredrummler/android/colorpicker/ColorPanelView.java
+++ b/library/src/main/java/com/jaredrummler/android/colorpicker/ColorPanelView.java
@@ -58,8 +58,12 @@ public class ColorPanelView extends View {
   private RectF centerRect = new RectF();
   private boolean showOldColor;
 
-  /* The width in pixels of the border surrounding the color panel. */
-  private int borderWidthPx;
+  /*
+    The width in pixels of the border surrounding the color panel.
+    We don't want a border around the color panel in Discord UI, so we can
+    just set the width to 0.
+  */
+  private int borderWidthPx = 0;
   private int borderColor = DEFAULT_BORDER_COLOR;
   private int color = Color.BLACK;
   private int shape;
@@ -111,7 +115,6 @@ public class ColorPanelView extends View {
       borderColor = typedArray.getColor(0, borderColor);
       typedArray.recycle();
     }
-    borderWidthPx = DrawingUtils.dpToPx(context, 1);
     borderPaint = new Paint();
     borderPaint.setAntiAlias(true);
     colorPaint = new Paint();

--- a/library/src/main/res/layout/cpv_dialog_color_picker.xml
+++ b/library/src/main/res/layout/cpv_dialog_color_picker.xml
@@ -19,8 +19,7 @@
             android:layout_height="wrap_content"
             android:gravity="center_vertical"
             android:orientation="horizontal"
-            android:paddingTop="16dp"
-            android:paddingBottom="16dp">
+            android:paddingTop="16dp">
 
             <com.jaredrummler.android.colorpicker.ColorPanelView
                 android:id="@+id/cpv_color_panel_new"


### PR DESCRIPTION
**Figma**: https://www.figma.com/file/lmWjzOAMnEhQS6iVqDmlGV/%E2%9C%85-Custom-Profiles-All-Platforms?node-id=2260%3A105463

To match our designs in Figma, this PR is
1) removing the border around the color panel (the color circle)
2) removing 16dp of extra padding between the color-hex input and the "select" button. There's already a 16dp margin above the "select" button, so if we were to keep this padding, it'd make the total spacing 32dp which doesn't match our designs.

I confirmed with product design that we want to remove the color panel border for the role color picker as well.

| Before | After |
| -- | -- |
| ![before](https://user-images.githubusercontent.com/3821698/125860170-174677ce-a035-4f4d-9429-b2358b81b977.png) | ![after](https://user-images.githubusercontent.com/3821698/125860214-db373f88-9b22-41cf-b0d4-ec4ce4db573f.png) |

